### PR TITLE
Conflict with sassc-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,20 +10,20 @@ gem 'pagy', '~> 5.10'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.6'
-gem 'sass-rails', '>= 6'
 gem 'tailwindcss-rails', '~> 2.0'
 gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 5.0'
 
+gem 'down', '~> 5.0'
 gem 'fastimage'
 gem 'image_processing', '~> 1.8'
 gem 'shrine', '~> 3.0'
 gem 'shrine-cloudinary', '~> 1.1'
 
+gem 'ffaker'
+
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'down', '~> 5.0'
-  gem 'ffaker'
 
   gem 'rspec-rails', '~> 5.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,16 +252,6 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     rubyzip (2.3.2)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -294,7 +284,6 @@ GEM
     tailwindcss-rails (2.0.8-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.2.1)
-    tilt (2.0.10)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -352,7 +341,6 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sass-rails (>= 6)
   selenium-webdriver
   shoulda-matchers (~> 5.0)
   shrine (~> 3.0)


### PR DESCRIPTION
Tailwind uses modern CSS features that are not recognized by the sassc-rails extension that was included by default in the Gemfile for Rails 6. In order to avoid any errors like SassC::SyntaxError, you must remove that gem from your Gemfile.